### PR TITLE
feat: create basic progression page and components

### DIFF
--- a/web/src/Routes.tsx
+++ b/web/src/Routes.tsx
@@ -33,6 +33,7 @@ const Routes = () => {
             <Route path="/games/sorting/setup" page={SortingGameSetupGamePage} name="sortingGameSetup" />
             <Route path="/games/sorting" page={SortingGameMenuPage} name="sortingGame" />
           </Set>
+          <Route path="/progression" page={ProgressionPage} name="progression" />
           <Route path="/games/matching" page={MatchingGamePage} name="matchingGame" />
           <Route path="/games" page={GamesPage} name="games" />
           <Route path="/profile" page={ProfilePage} name="profile" />

--- a/web/src/components/ProgressionCard/ProgressionCard.stories.tsx
+++ b/web/src/components/ProgressionCard/ProgressionCard.stories.tsx
@@ -1,0 +1,33 @@
+// When you've added props to your component,
+// pass Storybook's `args` through this story to control it from the addons panel:
+//
+// ```tsx
+// import type { ComponentStory } from '@storybook/react'
+//
+// export const generated: ComponentStory<typeof ProgressionCard> = (args) => {
+//   return <ProgressionCard {...args} />
+// }
+// ```
+//
+// See https://storybook.js.org/docs/react/writing-stories/args.
+
+import ProgressionCard from './ProgressionCard'
+
+import type { ComponentMeta, ComponentStory } from '@storybook/react'
+
+export const generated: ComponentStory<typeof ProgressionCard> = (args) => {
+  return <ProgressionCard {...args} />
+}
+
+export default {
+  title: 'Components/ProgressionCard',
+  component: ProgressionCard,
+  args: {
+    phoneme: 'Long I',
+    graphemes: [
+      { label: 'i', active: false },
+      { label: 'igh', active: true },
+      { label: 'y', active: false },
+    ],
+  },
+} as ComponentMeta<typeof ProgressionCard>

--- a/web/src/components/ProgressionCard/ProgressionCard.test.tsx
+++ b/web/src/components/ProgressionCard/ProgressionCard.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@redwoodjs/testing/web'
+
+import ProgressionCard from './ProgressionCard'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//    https://redwoodjs.com/docs/testing#testing-components
+
+describe('ProgressionCard', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(
+        <ProgressionCard
+          phoneme="Long I"
+          graphemes={[
+            {
+              label: 'i',
+              active: false,
+            },
+            {
+              label: 'igh',
+              active: false,
+            },
+            {
+              label: 'y',
+              active: false,
+            },
+            {
+              label: 'iCe',
+              active: true,
+            },
+          ]}
+        />
+      )
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/ProgressionCard/ProgressionCard.tsx
+++ b/web/src/components/ProgressionCard/ProgressionCard.tsx
@@ -1,0 +1,48 @@
+import { useState } from 'react'
+
+const ProgressionCard = ({
+  phoneme,
+  graphemes,
+}: {
+  phoneme: string
+  graphemes: { label: string; active: boolean }[]
+}) => {
+  // TODO: this is a hacky way to make the graphemes feel interactive.
+  // It should actually trigger a callback passed into the component
+  // that updates the state of the parent component.
+  const [hackyGraphemeState, setHackyGraphemeState] = useState(graphemes)
+
+  const handleClick = (currentGrapheme: string) => {
+    const newGraphemes = hackyGraphemeState.map((grapheme) => {
+      if (grapheme.label === currentGrapheme) {
+        return { ...grapheme, active: !grapheme.active }
+      }
+      return grapheme
+    })
+
+    setHackyGraphemeState(newGraphemes)
+  }
+
+  return (
+    <div className="card-compact card bg-gradient-to-tr from-base-300 to-base-200 text-base-content shadow-xl">
+      <div className="card-body">
+        <h2 className="card-title">{phoneme}</h2>
+        <div className="btn-group">
+          {hackyGraphemeState.map((grapheme) => (
+            <button
+              className={`btn-primary btn flex-1 normal-case ${
+                grapheme.active ? '' : 'btn-outline'
+              }`}
+              key={grapheme.label}
+              onClick={() => handleClick(grapheme.label)}
+            >
+              {grapheme.label}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default ProgressionCard

--- a/web/src/components/ProgressionCell/ProgressionCell.mock.ts
+++ b/web/src/components/ProgressionCell/ProgressionCell.mock.ts
@@ -1,0 +1,6 @@
+// Define your own mock data here:
+export const standard = (/* vars, { ctx, req } */) => ({
+  progression: {
+    id: 42,
+  },
+})

--- a/web/src/components/ProgressionCell/ProgressionCell.stories.tsx
+++ b/web/src/components/ProgressionCell/ProgressionCell.stories.tsx
@@ -1,0 +1,22 @@
+import { Loading, Empty, Failure, Success } from './ProgressionCell'
+import { standard } from './ProgressionCell.mock'
+
+import type { ComponentStory } from '@storybook/react'
+
+export const loading = () => {
+  return Loading ? <Loading /> : <></>
+}
+
+export const empty = () => {
+  return Empty ? <Empty /> : <></>
+}
+
+export const failure: ComponentStory<typeof Failure> = (args) => {
+  return Failure ? <Failure error={new Error('Oh no')} {...args} /> : <></>
+}
+
+export const success: ComponentStory<typeof Success> = (args) => {
+  return Success ? <Success {...standard()} {...args} /> : <></>
+}
+
+export default { title: 'Cells/ProgressionCell' }

--- a/web/src/components/ProgressionCell/ProgressionCell.test.tsx
+++ b/web/src/components/ProgressionCell/ProgressionCell.test.tsx
@@ -1,0 +1,41 @@
+import { render } from '@redwoodjs/testing/web'
+
+import { Loading, Empty, Failure, Success } from './ProgressionCell'
+
+// Generated boilerplate tests do not account for all circumstances
+// and can fail without adjustments, e.g. Float and DateTime types.
+//           Please refer to the RedwoodJS Testing Docs:
+//        https://redwoodjs.com/docs/testing#testing-cells
+// https://redwoodjs.com/docs/testing#jest-expect-type-considerations
+
+describe('ProgressionCell', () => {
+  it('renders Loading successfully', () => {
+    expect(() => {
+      render(<Loading />)
+    }).not.toThrow()
+  })
+
+  it('renders Empty successfully', async () => {
+    expect(() => {
+      render(<Empty />)
+    }).not.toThrow()
+  })
+
+  it('renders Failure successfully', async () => {
+    expect(() => {
+      render(<Failure error={new Error('Oh no')} />)
+    }).not.toThrow()
+  })
+
+  // When you're ready to test the actual output of your component render
+  // you could test that, for example, certain text is present:
+  //
+  // 1. import { screen } from '@redwoodjs/testing/web'
+  // 2. Add test: expect(screen.getByText('Hello, world')).toBeInTheDocument()
+
+  it('renders Success successfully', async () => {
+    expect(() => {
+      render(<Success />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/components/ProgressionCell/ProgressionCell.tsx
+++ b/web/src/components/ProgressionCell/ProgressionCell.tsx
@@ -1,0 +1,169 @@
+import ProgressionCard from 'src/components/ProgressionCard/ProgressionCard'
+
+import type { CellSuccessProps, CellFailureProps } from '@redwoodjs/web'
+import type {
+  FindProgressionQuery,
+  FindProgressionQueryVariables,
+} from 'types/graphql'
+
+export const QUERY = gql`
+  query FindProgressionQuery {
+    # placeholder query until we actually return data
+    __typename
+  }
+`
+
+export const Loading = () => <div>Loading...</div>
+
+export const Empty = () => <div>Empty</div>
+
+export const Failure = ({
+  error,
+}: CellFailureProps<FindProgressionQueryVariables>) => (
+  <div style={{ color: 'red' }}>Error: {error?.message}</div>
+)
+
+export const Success = (
+  _props: CellSuccessProps<FindProgressionQuery, FindProgressionQueryVariables>
+) => {
+  const RETURN_DATA = {
+    vowels: [
+      {
+        phoneme: 'Long I',
+        graphemes: [
+          {
+            label: 'i',
+            active: false,
+          },
+          {
+            label: 'igh',
+            active: false,
+          },
+          {
+            label: 'y',
+            active: false,
+          },
+          {
+            label: 'iCe',
+            active: true,
+          },
+        ],
+      },
+      {
+        phoneme: 'Long O',
+        graphemes: [
+          {
+            label: 'o',
+            active: false,
+          },
+          {
+            label: 'oa',
+            active: true,
+          },
+          {
+            label: 'ow',
+            active: true,
+          },
+        ],
+      },
+      {
+        phoneme: 'Long E',
+        graphemes: [
+          {
+            label: 'e',
+            active: true,
+          },
+          {
+            label: 'ee',
+            active: true,
+          },
+          {
+            label: 'ea',
+            active: true,
+          },
+          {
+            label: 'eCe',
+            active: true,
+          },
+        ],
+      },
+    ],
+    consonants: [
+      {
+        phoneme: '/f/',
+        graphemes: [
+          {
+            label: 'f',
+            active: false,
+          },
+          {
+            label: 'ff',
+            active: true,
+          },
+          {
+            label: 'ph',
+            active: true,
+          },
+        ],
+      },
+      {
+        phoneme: '/s/',
+        graphemes: [
+          {
+            label: 's',
+            active: false,
+          },
+          {
+            label: 'c',
+            active: true,
+          },
+          {
+            label: 'ss',
+            active: true,
+          },
+        ],
+      },
+      {
+        phoneme: '/k/',
+        graphemes: [
+          {
+            label: 'k',
+            active: false,
+          },
+          {
+            label: 'c',
+            active: false,
+          },
+          {
+            label: 'ck',
+            active: true,
+          },
+        ],
+      },
+    ],
+  }
+  return (
+    <>
+      <h1 className="font-2xl">Vowels</h1>
+      <div className="grid grid-cols-3 gap-4">
+        {RETURN_DATA.vowels.map((option) => (
+          <ProgressionCard
+            key={option.phoneme}
+            phoneme={option.phoneme}
+            graphemes={option.graphemes}
+          />
+        ))}
+      </div>
+      <h1 className="font-2xl">Consonants</h1>
+      <div className="grid grid-cols-3 gap-4">
+        {RETURN_DATA.consonants.map((option) => (
+          <ProgressionCard
+            key={option.phoneme}
+            phoneme={option.phoneme}
+            graphemes={option.graphemes}
+          />
+        ))}
+      </div>
+    </>
+  )
+}

--- a/web/src/pages/ProgressionPage/ProgressionPage.stories.tsx
+++ b/web/src/pages/ProgressionPage/ProgressionPage.stories.tsx
@@ -1,0 +1,12 @@
+import ProgressionPage from './ProgressionPage'
+
+import type { ComponentStory, ComponentMeta } from '@storybook/react'
+
+export const generated: ComponentStory<typeof ProgressionPage> = (args) => {
+  return <ProgressionPage {...args} />
+}
+
+export default {
+  title: 'Pages/ProgressionPage',
+  component: ProgressionPage,
+} as ComponentMeta<typeof ProgressionPage>

--- a/web/src/pages/ProgressionPage/ProgressionPage.test.tsx
+++ b/web/src/pages/ProgressionPage/ProgressionPage.test.tsx
@@ -1,0 +1,14 @@
+import { render } from '@redwoodjs/testing/web'
+
+import ProgressionPage from './ProgressionPage'
+
+//   Improve this test with help from the Redwood Testing Doc:
+//   https://redwoodjs.com/docs/testing#testing-pages-layouts
+
+describe('ProgressionPage', () => {
+  it('renders successfully', () => {
+    expect(() => {
+      render(<ProgressionPage />)
+    }).not.toThrow()
+  })
+})

--- a/web/src/pages/ProgressionPage/ProgressionPage.tsx
+++ b/web/src/pages/ProgressionPage/ProgressionPage.tsx
@@ -1,0 +1,15 @@
+import { MetaTags } from '@redwoodjs/web'
+
+import ProgressionCell from 'src/components/ProgressionCell'
+
+const ProgressionPage = () => {
+  return (
+    <>
+      <MetaTags title="Progression" description="Progression page" />
+
+      <ProgressionCell />
+    </>
+  )
+}
+
+export default ProgressionPage


### PR DESCRIPTION
This is a basic configuration page for the teacher's view. This is with the
eventual goal of replacing the "new game" page with an automated game
configuration flow, where a teacher selects all grapheme/phoneme combos that
students have unlocked and the game randomly selects two to practice with. 
